### PR TITLE
[codex] Fix WhatsApp bot sync and stale sessions

### DIFF
--- a/backend/src/controllers/agendamento.js
+++ b/backend/src/controllers/agendamento.js
@@ -81,6 +81,18 @@ async function obterSnapshotServico({
   };
 }
 
+async function normalizarBarbeiroUsuarioId(barbeiroId) {
+  const id = String(barbeiroId || '').trim();
+  if (!id) return null;
+
+  const result = await pool.query(
+    "SELECT id FROM usuarios WHERE id = $1 AND tipo = 'barbeiro' LIMIT 1",
+    [id]
+  );
+
+  return result.rows[0]?.id || null;
+}
+
 async function montarPayloadWhatsAppAgendamento({
   barbearia_id,
   servico_id,
@@ -144,6 +156,24 @@ async function enviarConfirmacaoAutomaticaAgendamento(barbeariaId, whatsappPaylo
     phoneNumber: whatsappPayload.cliente.telefone,
     message: whatsappPayload.cliente.mensagem,
   });
+}
+
+async function enviarConfirmacaoAutomaticaAgendamentoSeguro(barbeariaId, whatsappPayload) {
+  try {
+    return await enviarConfirmacaoAutomaticaAgendamento(barbeariaId, whatsappPayload);
+  } catch (error) {
+    console.warn('[AGENDAMENTO.whatsapp] Falha ao enviar confirmacao automatica', {
+      barbeariaId,
+      message: error?.message,
+      status: error?.status,
+    });
+
+    return {
+      sent: false,
+      reason: 'BOT_CONFIRMATION_FAILED',
+      error: error?.message || 'Nao foi possivel enviar a confirmacao automatica pelo WhatsApp.',
+    };
+  }
 }
 
 async function enviarSolicitacaoAvaliacaoConclusao({
@@ -368,6 +398,8 @@ async function createAgendamento(req, res) {
     if (snapshotServico.error) {
       return res.status(400).json({ error: snapshotServico.error });
     }
+
+    const barbeiroUsuarioId = await normalizarBarbeiroUsuarioId(barbeiro_id);
     
     const result = await pool.query(
       `INSERT INTO agendamentos (
@@ -390,7 +422,7 @@ async function createAgendamento(req, res) {
         snapshotServico.servicoNomeSnapshot,
         snapshotServico.servicoPrecoSnapshot,
         clienteId,
-        barbeiro_id || null,
+        barbeiroUsuarioId,
         data,
         hora,
         observacoes || null,
@@ -403,11 +435,11 @@ async function createAgendamento(req, res) {
       servico_id: snapshotServico.servicoId,
       servico_nome: snapshotServico.servicoNomeSnapshot,
       cliente_id: clienteId,
-      barbeiro_id,
+      barbeiro_id: barbeiroUsuarioId,
       data,
       hora,
     });
-    const whatsappAutomation = await enviarConfirmacaoAutomaticaAgendamento(barbearia_id, whatsapp);
+    const whatsappAutomation = await enviarConfirmacaoAutomaticaAgendamentoSeguro(barbearia_id, whatsapp);
 
     res.status(201).json({
       agendamento: result.rows[0],
@@ -484,6 +516,8 @@ async function createAgendamentoByEmail(req, res) {
       return res.status(400).json({ error: snapshotServico.error });
     }
 
+    const barbeiroUsuarioId = await normalizarBarbeiroUsuarioId(barbeiro_id);
+
     const result = await pool.query(
       `INSERT INTO agendamentos (
          barbearia_id,
@@ -505,7 +539,7 @@ async function createAgendamentoByEmail(req, res) {
         snapshotServico.servicoNomeSnapshot,
         snapshotServico.servicoPrecoSnapshot,
         cliente.id,
-        barbeiro_id || null,
+        barbeiroUsuarioId,
         data,
         hora,
         observacoes || null,
@@ -518,11 +552,11 @@ async function createAgendamentoByEmail(req, res) {
       servico_id: snapshotServico.servicoId,
       servico_nome: snapshotServico.servicoNomeSnapshot,
       cliente_id: cliente.id,
-      barbeiro_id,
+      barbeiro_id: barbeiroUsuarioId,
       data,
       hora,
     });
-    const whatsappAutomation = await enviarConfirmacaoAutomaticaAgendamento(barbearia_id, whatsapp);
+    const whatsappAutomation = await enviarConfirmacaoAutomaticaAgendamentoSeguro(barbearia_id, whatsapp);
 
     res.status(201).json({
       agendamento: result.rows[0],

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -57,7 +57,14 @@ app.get('/health', (req, res) => {
   });
 });
 
-app.use('/uploads', express.static(path.join(__dirname, '../uploads')));
+app.use(
+  '/uploads',
+  (req, res, next) => {
+    res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
+    next();
+  },
+  express.static(path.join(__dirname, '../uploads'))
+);
 
 // API Routes
 app.use('/api/whatsapp', whatsappRoutes);

--- a/backend/src/routes/internalBotSync.js
+++ b/backend/src/routes/internalBotSync.js
@@ -75,6 +75,34 @@ function serializarAgendamentoPayload(payload = {}) {
   };
 }
 
+async function normalizarServicoId(servicoId, barbeariaId) {
+  const id = nullableText(servicoId);
+  if (!id) return null;
+
+  const result = await pool.query(
+    'SELECT id FROM servicos WHERE id = $1 AND barbearia_id = $2 LIMIT 1',
+    [id, barbeariaId]
+  );
+
+  return result.rows[0]?.id || null;
+}
+
+async function normalizarUsuarioId(usuarioId, { tipo } = {}) {
+  const id = nullableText(usuarioId);
+  if (!id) return null;
+
+  const params = [id];
+  let query = 'SELECT id FROM usuarios WHERE id = $1';
+  if (tipo) {
+    params.push(tipo);
+    query += ' AND tipo = $2';
+  }
+  query += ' LIMIT 1';
+
+  const result = await pool.query(query, params);
+  return result.rows[0]?.id || null;
+}
+
 async function listChangedBarbeariaIds({ since, limit }) {
   await ensureServicoAvailabilitySchema();
 
@@ -180,6 +208,16 @@ router.post('/appointments', async (req, res) => {
       });
     }
 
+    const [servicoId, clienteId, barbeiroId] = await Promise.all([
+      normalizarServicoId(appointment.servico_id, appointment.barbearia_id),
+      normalizarUsuarioId(appointment.cliente_id),
+      normalizarUsuarioId(appointment.barbeiro_id, { tipo: 'barbeiro' }),
+    ]);
+
+    appointment.servico_id = servicoId;
+    appointment.cliente_id = clienteId;
+    appointment.barbeiro_id = barbeiroId;
+
     if (appointment.status !== 'cancelado') {
       const conflito = await pool.query(
         `SELECT id
@@ -269,6 +307,13 @@ router.post('/appointments', async (req, res) => {
     console.error('[INTERNAL_BOT_SYNC.appointments] Falha ao sincronizar agendamento do bot', {
       message: error?.message,
       code: error?.code,
+      appointment: {
+        id: req.body?.appointment?.id || req.body?.agendamento?.id || req.body?.id,
+        barbearia_id: req.body?.appointment?.barbearia_id || req.body?.agendamento?.barbearia_id || req.body?.barbearia_id,
+        servico_id: req.body?.appointment?.servico_id || req.body?.agendamento?.servico_id || req.body?.servico_id,
+        data: req.body?.appointment?.data || req.body?.agendamento?.data || req.body?.data,
+        hora: req.body?.appointment?.hora || req.body?.agendamento?.hora || req.body?.hora,
+      },
     }, error);
 
     res.status(500).json({

--- a/bot/src/scheduler.js
+++ b/bot/src/scheduler.js
@@ -7,6 +7,7 @@ const { runSchedulerTick } = require('./services/baileysRuntime');
 const { markStaleChatbotSessionsAsAbandoned } = require('./services/chatbotTraining');
 const { listActiveSessionIds } = require('./services/botStateStore');
 const { reconcileFromBackend } = require('./services/backendReconciler');
+const { syncPendingAppointmentsToBackend } = require('./services/backendAppointments');
 
 let running = false;
 
@@ -20,6 +21,10 @@ async function tick() {
     const scheduler = await runSchedulerTick();
     const activeSessionIds = await listActiveSessionIds().catch(() => []);
     const backendSync = await reconcileFromBackend().catch((error) => ({
+      ok: false,
+      error: error?.message,
+    }));
+    const appointmentSync = await syncPendingAppointmentsToBackend({ limit: 50 }).catch((error) => ({
       ok: false,
       error: error?.message,
     }));
@@ -38,6 +43,7 @@ async function tick() {
       redis,
       queueDepths,
       backendSync,
+      appointmentSync,
       activeSessions: scheduler.activeSessions,
       localRuntimeSessions: scheduler.localRuntimeSessions,
     });

--- a/bot/src/services/agendamentoSchema.js
+++ b/bot/src/services/agendamentoSchema.js
@@ -37,6 +37,9 @@ async function executarGarantiasSchema() {
       avaliacao_nota INTEGER,
       avaliacao_comentario TEXT,
       avaliacao_registrada_em DATETIME,
+      backend_sync_status VARCHAR(30) DEFAULT 'pending',
+      backend_sync_error TEXT,
+      backend_synced_at DATETIME,
       observacoes TEXT,
       origem VARCHAR(30) DEFAULT 'app',
       created_at DATETIME DEFAULT NOW(),
@@ -61,7 +64,10 @@ async function executarGarantiasSchema() {
     ADD COLUMN IF NOT EXISTS servico_preco_snapshot NUMERIC(10,2),
     ADD COLUMN IF NOT EXISTS avaliacao_nota INTEGER,
     ADD COLUMN IF NOT EXISTS avaliacao_comentario TEXT,
-    ADD COLUMN IF NOT EXISTS avaliacao_registrada_em DATETIME
+    ADD COLUMN IF NOT EXISTS avaliacao_registrada_em DATETIME,
+    ADD COLUMN IF NOT EXISTS backend_sync_status VARCHAR(30) DEFAULT 'pending',
+    ADD COLUMN IF NOT EXISTS backend_sync_error TEXT,
+    ADD COLUMN IF NOT EXISTS backend_synced_at DATETIME
   `);
 }
 

--- a/bot/src/services/backendAppointments.js
+++ b/bot/src/services/backendAppointments.js
@@ -176,6 +176,15 @@ async function syncPendingAppointmentsToBackend({ limit = 50 } = {}) {
       synced += 1;
     } catch (error) {
       failed += 1;
+      console.warn('[BACKEND_APPOINTMENTS] Falha ao sincronizar agendamento pendente', {
+        agendamentoId: item.id,
+        barbeariaId: item.barbearia_id,
+        code: error?.code,
+        status: error?.status,
+        message: error?.message,
+        payload: error?.payload,
+      });
+
       await markAppointmentBackendSyncStatus(item.id, 'failed', error?.message || 'Falha ao sincronizar com a API principal.')
         .catch(() => undefined);
     }

--- a/bot/src/services/backendAppointments.js
+++ b/bot/src/services/backendAppointments.js
@@ -1,10 +1,19 @@
 const config = require('../config');
+const pool = require('../config/database');
+const { ensureAgendamentoSchema } = require('./agendamentoSchema');
 
 function normalizarTexto(valor = '') {
   return String(valor || '').trim();
 }
 
 function normalizarData(valor = '') {
+  if (valor instanceof Date) {
+    const ano = valor.getUTCFullYear();
+    const mes = String(valor.getUTCMonth() + 1).padStart(2, '0');
+    const dia = String(valor.getUTCDate()).padStart(2, '0');
+    return `${ano}-${mes}-${dia}`;
+  }
+
   const match = String(valor || '').match(/\d{4}-\d{2}-\d{2}/);
   return match ? match[0] : '';
 }
@@ -85,7 +94,104 @@ async function syncAppointmentToBackend(agendamento = {}) {
   }
 }
 
+async function markAppointmentBackendSyncStatus(appointmentId, status, errorMessage = '') {
+  const id = normalizarTexto(appointmentId);
+  if (!id) return;
+
+  if (status === 'synced') {
+    await pool.query(
+      `UPDATE agendamentos
+       SET backend_sync_status = $2,
+           backend_sync_error = NULL,
+           backend_synced_at = CURRENT_TIMESTAMP,
+           updated_at = CURRENT_TIMESTAMP
+       WHERE id = $1`,
+      [id, status]
+    );
+    return;
+  }
+
+  await pool.query(
+    `UPDATE agendamentos
+     SET backend_sync_status = $2,
+         backend_sync_error = $3,
+         updated_at = CURRENT_TIMESTAMP
+     WHERE id = $1`,
+    [id, status || 'failed', normalizarTexto(errorMessage).slice(0, 1000) || null]
+  );
+}
+
+async function syncPendingAppointmentsToBackend({ limit = 50 } = {}) {
+  await ensureAgendamentoSchema();
+
+  if (!config.backendSync.enabled) {
+    return { skipped: true, reason: 'BACKEND_SYNC_DISABLED' };
+  }
+
+  const safeLimit = Math.min(200, Math.max(1, Math.floor(Number(limit) || 50)));
+  const result = await pool.query(
+    `SELECT
+       id,
+       barbearia_id,
+       servico_id,
+       servico_nome_snapshot,
+       servico_preco_snapshot,
+       cliente_id,
+       cliente_nome_externo,
+       cliente_telefone_externo,
+       barbeiro_id,
+       data,
+       hora,
+       status,
+       chatbot_session_id,
+       observacoes,
+       origem
+     FROM agendamentos
+     WHERE origem = 'whatsapp'
+       AND status NOT IN ('cancelado', 'faltou')
+       AND (
+         backend_sync_status IS NULL
+         OR backend_sync_status = ''
+         OR backend_sync_status != 'synced'
+       )
+     ORDER BY created_at ASC
+     LIMIT $1`,
+    [safeLimit]
+  );
+
+  const items = result.rows || [];
+  let synced = 0;
+  let failed = 0;
+
+  for (const item of items) {
+    try {
+      const response = await syncAppointmentToBackend(item);
+      if (!response?.agendamento) {
+        const error = new Error('API principal confirmou a chamada, mas nao retornou o agendamento sincronizado.');
+        error.code = 'BACKEND_SYNC_EMPTY_RESPONSE';
+        throw error;
+      }
+
+      await markAppointmentBackendSyncStatus(item.id, 'synced');
+      synced += 1;
+    } catch (error) {
+      failed += 1;
+      await markAppointmentBackendSyncStatus(item.id, 'failed', error?.message || 'Falha ao sincronizar com a API principal.')
+        .catch(() => undefined);
+    }
+  }
+
+  return {
+    ok: true,
+    checked: items.length,
+    synced,
+    failed,
+  };
+}
+
 module.exports = {
   serializarAgendamento,
   syncAppointmentToBackend,
+  markAppointmentBackendSyncStatus,
+  syncPendingAppointmentsToBackend,
 };

--- a/bot/src/services/chatbotConversation.js
+++ b/bot/src/services/chatbotConversation.js
@@ -947,6 +947,7 @@ async function criarAgendamentoExterno({
       code: error?.code,
       status: error?.status,
       message: error?.message,
+      payload: error?.payload,
     }, error);
 
     await markAppointmentBackendSyncStatus(agendamento?.id, 'failed', error?.message || 'Falha ao sincronizar com a agenda principal.')

--- a/bot/src/services/chatbotConversation.js
+++ b/bot/src/services/chatbotConversation.js
@@ -2,7 +2,10 @@ const pool = require('../config/database');
 const WhatsAppService = require('./whatsapp');
 const { ensureAgendamentoSchema } = require('./agendamentoSchema');
 const { registrarAvaliacaoAtendimento, normalizarAvaliacaoNota } = require('./barbeariaRatings');
-const { syncAppointmentToBackend } = require('./backendAppointments');
+const {
+  markAppointmentBackendSyncStatus,
+  syncAppointmentToBackend,
+} = require('./backendAppointments');
 const {
   ensureChatbotTrainingSchema,
   getChatbotOperationalSettings,
@@ -904,9 +907,10 @@ async function criarAgendamentoExterno({
        status,
        chatbot_session_id,
        observacoes,
-       origem
+       origem,
+       backend_sync_status
       )
-     VALUES ($1, $2, $3, $4, NULL, $5, $6, $7, $8, 'pendente', $9, $10, 'whatsapp')
+     VALUES ($1, $2, $3, $4, NULL, $5, $6, $7, $8, 'pendente', $9, $10, 'whatsapp', 'pending')
       RETURNING *`,
     [
       barbeariaId,
@@ -926,11 +930,16 @@ async function criarAgendamentoExterno({
   try {
     const backendSync = await syncAppointmentToBackend(agendamento);
     if (backendSync?.agendamento) {
+      await markAppointmentBackendSyncStatus(agendamento.id, 'synced');
       return {
         created: true,
         agendamento: backendSync.agendamento,
       };
     }
+
+    const syncError = new Error('API principal confirmou a chamada, mas nao retornou o agendamento sincronizado.');
+    syncError.code = 'BACKEND_SYNC_EMPTY_RESPONSE';
+    throw syncError;
   } catch (error) {
     console.error('[CHATBOT_CONVERSATION] Falha ao sincronizar agendamento com a API principal', {
       barbeariaId,
@@ -939,6 +948,9 @@ async function criarAgendamentoExterno({
       status: error?.status,
       message: error?.message,
     }, error);
+
+    await markAppointmentBackendSyncStatus(agendamento?.id, 'failed', error?.message || 'Falha ao sincronizar com a agenda principal.')
+      .catch(() => undefined);
 
     await pool.query(
       `UPDATE agendamentos

--- a/bot/src/services/whatsappBot.js
+++ b/bot/src/services/whatsappBot.js
@@ -16,6 +16,7 @@ const { getBarbeariaSubscriptionAccess } = require('./subscriptionAccess');
 const { getChatbotOperationalSettings } = require('./chatbotTraining');
 
 const WHATSAPP_BOT_ALLOWED_STATUSES = ['active', 'trialing', 'past_due'];
+const RECOVERABLE_STALE_STATUSES = new Set(['ready', 'authenticated', 'starting', 'qr_ready']);
 
 function assinaturaPermiteBot(status) {
   return WHATSAPP_BOT_ALLOWED_STATUSES.includes(String(status || '').trim());
@@ -36,7 +37,7 @@ function criarErroAssinaturaBloqueandoBot(status) {
 
 async function getBotState(barbeariaId) {
   const normalizedBarbeariaId = normalizarBarbeariaId(barbeariaId);
-  const state = await readBotState(normalizedBarbeariaId);
+  const state = await recoverStaleBotState(normalizedBarbeariaId, await readBotState(normalizedBarbeariaId));
   return toPublicState(state);
 }
 
@@ -48,6 +49,51 @@ async function waitForJobResult(queue, job, timeoutMs = 10000) {
   } catch {
     return null;
   }
+}
+
+async function enqueueReconnectJob(normalizedBarbeariaId, reason = 'status-recover') {
+  const queues = getQueues();
+  return queues.session.add('reconnect', {
+    barbeariaId: normalizedBarbeariaId,
+  }, {
+    jobId: buildJobId([reason, normalizedBarbeariaId, Date.now(), Math.random().toString(36).slice(2, 8)]),
+  });
+}
+
+async function recoverStaleBotState(normalizedBarbeariaId, state = {}) {
+  if (!normalizedBarbeariaId || !RECOVERABLE_STALE_STATUSES.has(String(state.status || ''))) {
+    return state;
+  }
+
+  if (!state.requestedPhoneNumber) {
+    return state;
+  }
+
+  const activeSessionIds = await listActiveSessionIds().catch(() => []);
+  if (activeSessionIds.includes(normalizedBarbeariaId)) {
+    return state;
+  }
+
+  const recoveringState = await writeBotState(normalizedBarbeariaId, {
+    status: 'starting',
+    isAuthenticated: false,
+    qrCodeDataUrl: '',
+    qrCodeText: '',
+    loadingPercent: 35,
+    lastError: '',
+    lastMessage: 'Sessão do WhatsApp sem runtime ativo. Reconectando automaticamente...',
+  });
+
+  await enqueueReconnectJob(normalizedBarbeariaId).catch(async (error) => {
+    await writeBotState(normalizedBarbeariaId, {
+      status: 'error',
+      loadingPercent: 0,
+      lastError: error?.message || 'Falha ao enfileirar reconexão do WhatsApp.',
+      lastMessage: 'Não foi possível reconectar automaticamente. Gere um novo QR Code.',
+    }).catch(() => undefined);
+  });
+
+  return recoveringState;
 }
 
 async function enqueueSessionJob(name, data = {}, { wait = true } = {}) {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,18 +1,28 @@
-import type { Metadata } from 'next'
+import type { Metadata, Viewport } from 'next'
 import './globals.css'
 import Providers from './providers'
 
 export const metadata: Metadata = {
   title: 'O Corte Certo',
   description: 'App de barbearia - Agendamento online',
-  viewport: 'width=device-width, initial-scale=1, maximum-scale=1',
-  themeColor: '#000000',
   manifest: '/manifest.json',
+  icons: {
+    icon: '/logo.png',
+    shortcut: '/logo.png',
+    apple: '/logo.png',
+  },
   appleWebApp: {
     capable: true,
     statusBarStyle: 'black-translucent',
     title: 'O Corte Certo'
   }
+}
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  themeColor: '#000000',
 }
 
 export default function RootLayout({


### PR DESCRIPTION
## What changed

- Fixes WhatsApp bot appointment sync when MySQL returns `DATE` values as JavaScript `Date` objects.
- Tracks backend sync status for bot-created appointments and lets the scheduler retry pending syncs.
- Prevents the bot from confirming a WhatsApp booking unless the main API accepts the appointment.
- Recovers stale WhatsApp bot states where the UI says connected but the worker has no active runtime session.
- Makes manual appointment creation tolerate non-user professional IDs and avoids failing the booking if WhatsApp confirmation fails.
- Allows cross-origin upload images and moves Next viewport metadata to the supported export.

## Why

Production logs showed `INVALID_APPOINTMENT_SYNC_PAYLOAD`, which meant WhatsApp bookings were confirmed in chat but never written to the main agenda. Separately, worker logs showed `sessions: 0` while the UI still displayed connected, leaving some barbershops unable to receive bot replies.

## Validation

- `node --check` on changed backend and bot JavaScript files
- `git diff --check`
- `npm run build` in `frontend`