### PR TITLE
[codex] Add WhatsApp reschedule protocols

### DIFF
--- a/backend/scripts/create-tables.js
+++ b/backend/scripts/create-tables.js
@@ -117,6 +117,7 @@ async function createTables() {
         data DATE NOT NULL,
         hora TIME NOT NULL,
         status VARCHAR(20) DEFAULT 'pendente',
+        protocolo_atendimento VARCHAR(20),
         chatbot_session_id CHAR(36),
         servico_nome_snapshot TEXT,
         servico_preco_snapshot NUMERIC(10, 2),
@@ -137,11 +138,17 @@ async function createTables() {
       ADD COLUMN IF NOT EXISTS cliente_telefone_externo VARCHAR(20),
       ADD COLUMN IF NOT EXISTS origem VARCHAR(30) DEFAULT 'app',
       ADD COLUMN IF NOT EXISTS chatbot_session_id CHAR(36),
+      ADD COLUMN IF NOT EXISTS protocolo_atendimento VARCHAR(20),
       ADD COLUMN IF NOT EXISTS servico_nome_snapshot TEXT,
       ADD COLUMN IF NOT EXISTS servico_preco_snapshot NUMERIC(10, 2),
       ADD COLUMN IF NOT EXISTS avaliacao_nota INTEGER,
       ADD COLUMN IF NOT EXISTS avaliacao_comentario TEXT,
       ADD COLUMN IF NOT EXISTS avaliacao_registrada_em DATETIME
+    `);
+
+    await client.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_agendamentos_protocolo_atendimento
+      ON agendamentos (protocolo_atendimento)
     `);
     
     // Tabela fidelidade

--- a/backend/src/controllers/agendamento.js
+++ b/backend/src/controllers/agendamento.js
@@ -1,6 +1,7 @@
 const pool = require('../config/database');
 const WhatsAppService = require('../services/whatsapp');
 const { ensureAgendamentoSchema } = require('../services/agendamentoSchema');
+const { gerarProtocoloAtendimentoUnico } = require('../services/appointmentProtocol');
 const {
   sendTextMessage,
   registrarSolicitacaoAvaliacaoPendente,
@@ -41,6 +42,24 @@ function normalizarServicoPreco(value) {
   const preco = Number(value);
   if (!Number.isFinite(preco) || preco < 0) return null;
   return Number(preco.toFixed(2));
+}
+
+function normalizarDataAgendamento(value = '') {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    const ano = value.getUTCFullYear();
+    const mes = String(value.getUTCMonth() + 1).padStart(2, '0');
+    const dia = String(value.getUTCDate()).padStart(2, '0');
+    return `${ano}-${mes}-${dia}`;
+  }
+
+  const match = String(value || '').match(/\d{4}-\d{2}-\d{2}/);
+  return match ? match[0] : String(value || '').trim();
+}
+
+function normalizarHoraAgendamento(value = '') {
+  const match = String(value || '').match(/(\d{2}):(\d{2})(?::(\d{2}))?/);
+  if (!match) return String(value || '').trim();
+  return `${match[1]}:${match[2]}:${match[3] || '00'}`;
 }
 
 async function obterSnapshotServico({
@@ -101,6 +120,7 @@ async function montarPayloadWhatsAppAgendamento({
   barbeiro_id,
   data,
   hora,
+  protocoloAtendimento,
 }) {
   const resultadoVazio = { cliente: null, barbearia: null };
 
@@ -139,6 +159,7 @@ async function montarPayloadWhatsAppAgendamento({
     enderecoBarbearia: barbearia.endereco,
     telefoneBarbearia: barbearia.whatsapp_link || barbearia.telefone,
     barbeiroNome: barbeiro?.nome || '',
+    protocoloAtendimento,
   });
 }
 
@@ -172,6 +193,62 @@ async function enviarConfirmacaoAutomaticaAgendamentoSeguro(barbeariaId, whatsap
       sent: false,
       reason: 'BOT_CONFIRMATION_FAILED',
       error: error?.message || 'Nao foi possivel enviar a confirmacao automatica pelo WhatsApp.',
+    };
+  }
+}
+
+async function enviarRemarcacaoAutomaticaAgendamentoSeguro({
+  barbeariaId,
+  phoneNumber,
+  nomeCliente,
+  nomeBarbearia,
+  enderecoBarbearia,
+  servicoNome,
+  dataAnterior,
+  horaAnterior,
+  data,
+  hora,
+  protocoloAtendimento,
+}) {
+  const telefone = String(phoneNumber || '').trim();
+
+  if (!telefone || !WhatsAppService.validarTelefone(telefone)) {
+    return {
+      sent: false,
+      reason: 'NO_CLIENT_WHATSAPP',
+      error: 'Cliente sem telefone valido para automacao do WhatsApp.',
+    };
+  }
+
+  const mensagem = WhatsAppService.templateAgendamentoRemarcadoCliente({
+    nomeCliente,
+    nomeBarbearia,
+    enderecoBarbearia,
+    servico: servicoNome,
+    dataAnterior,
+    horaAnterior,
+    data,
+    hora,
+    protocoloAtendimento,
+  });
+
+  try {
+    return await sendTextMessage({
+      barbeariaId,
+      phoneNumber: telefone,
+      message: mensagem,
+    });
+  } catch (error) {
+    console.warn('[AGENDAMENTO.whatsapp] Falha ao avisar remarcacao automaticamente', {
+      barbeariaId,
+      message: error?.message,
+      status: error?.status,
+    });
+
+    return {
+      sent: false,
+      reason: 'BOT_RESCHEDULE_NOTIFICATION_FAILED',
+      error: error?.message || 'Nao foi possivel avisar a remarcacao pelo WhatsApp.',
     };
   }
 }
@@ -400,6 +477,7 @@ async function createAgendamento(req, res) {
     }
 
     const barbeiroUsuarioId = await normalizarBarbeiroUsuarioId(barbeiro_id);
+    const protocoloAtendimento = await gerarProtocoloAtendimentoUnico(pool);
     
     const result = await pool.query(
       `INSERT INTO agendamentos (
@@ -411,10 +489,11 @@ async function createAgendamento(req, res) {
          barbeiro_id,
          data,
          hora,
+         protocolo_atendimento,
          observacoes,
          origem
        )
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
        RETURNING *`,
       [
         barbearia_id,
@@ -425,6 +504,7 @@ async function createAgendamento(req, res) {
         barbeiroUsuarioId,
         data,
         hora,
+        protocoloAtendimento,
         observacoes || null,
         origem || 'app',
       ]
@@ -438,6 +518,7 @@ async function createAgendamento(req, res) {
       barbeiro_id: barbeiroUsuarioId,
       data,
       hora,
+      protocoloAtendimento,
     });
     const whatsappAutomation = await enviarConfirmacaoAutomaticaAgendamentoSeguro(barbearia_id, whatsapp);
 
@@ -517,6 +598,7 @@ async function createAgendamentoByEmail(req, res) {
     }
 
     const barbeiroUsuarioId = await normalizarBarbeiroUsuarioId(barbeiro_id);
+    const protocoloAtendimento = await gerarProtocoloAtendimentoUnico(pool);
 
     const result = await pool.query(
       `INSERT INTO agendamentos (
@@ -528,10 +610,11 @@ async function createAgendamentoByEmail(req, res) {
          barbeiro_id,
          data,
          hora,
+         protocolo_atendimento,
          observacoes,
          origem
        )
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
        RETURNING *`,
       [
         barbearia_id,
@@ -542,6 +625,7 @@ async function createAgendamentoByEmail(req, res) {
         barbeiroUsuarioId,
         data,
         hora,
+        protocoloAtendimento,
         observacoes || null,
         origem || 'painel',
       ]
@@ -555,6 +639,7 @@ async function createAgendamentoByEmail(req, res) {
       barbeiro_id: barbeiroUsuarioId,
       data,
       hora,
+      protocoloAtendimento,
     });
     const whatsappAutomation = await enviarConfirmacaoAutomaticaAgendamentoSeguro(barbearia_id, whatsapp);
 
@@ -597,13 +682,15 @@ async function updateAgendamento(req, res) {
          a.data,
          a.hora,
          a.barbearia_id,
+         a.protocolo_atendimento,
          a.avaliacao_nota,
          a.avaliacao_comentario,
          a.avaliacao_registrada_em,
          COALESCE(c.nome, a.cliente_nome_externo, 'Cliente') AS cliente_nome,
          COALESCE(c.telefone, a.cliente_telefone_externo, '') AS cliente_telefone,
          COALESCE(a.servico_nome_snapshot, s.nome, NULLIF(a.observacoes, '')) AS servico_nome,
-         COALESCE(b.nome, '') AS barbearia_nome
+         COALESCE(b.nome, '') AS barbearia_nome,
+         COALESCE(b.endereco, '') AS barbearia_endereco
        FROM agendamentos a
        LEFT JOIN usuarios c ON c.id = a.cliente_id
        LEFT JOIN servicos s ON s.id = a.servico_id
@@ -621,6 +708,8 @@ async function updateAgendamento(req, res) {
     }
 
     const atual = atualResult.rows[0];
+    const dataAtual = normalizarDataAgendamento(atual.data);
+    const horaAtual = normalizarHoraAgendamento(atual.hora);
     const validacaoGestao = await validarGestaoAgenda(atual.barbearia_id);
     if (!validacaoGestao.ok) {
       await client.query('ROLLBACK');
@@ -633,11 +722,11 @@ async function updateAgendamento(req, res) {
       ? atual.status
       : String(status).trim().toLowerCase();
     const dataFinal = data === undefined || data === null || data === ''
-      ? atual.data
-      : String(data).trim();
+      ? dataAtual
+      : normalizarDataAgendamento(data);
     const horaFinal = hora === undefined || hora === null || hora === ''
-      ? atual.hora
-      : String(hora).trim();
+      ? horaAtual
+      : normalizarHoraAgendamento(hora);
 
     const statusValido = ['pendente', 'confirmado', 'cancelado', 'em_atendimento', 'concluido', 'faltou'].includes(statusFinal);
     if (!statusValido) {
@@ -681,7 +770,7 @@ async function updateAgendamento(req, res) {
       ? (atual.avaliacao_registrada_em || new Date().toISOString())
       : null;
 
-    const alterouHorario = dataFinal !== atual.data || horaFinal !== atual.hora;
+    const alterouHorario = dataFinal !== dataAtual || horaFinal !== horaAtual;
     if (alterouHorario) {
       const conflito = await client.query(
         `SELECT id
@@ -703,6 +792,8 @@ async function updateAgendamento(req, res) {
       }
     }
 
+    const protocoloAtendimento = atual.protocolo_atendimento || await gerarProtocoloAtendimentoUnico(client);
+
     const result = await client.query(
       `UPDATE agendamentos
        SET status = $1,
@@ -711,8 +802,9 @@ async function updateAgendamento(req, res) {
            avaliacao_nota = $4,
            avaliacao_comentario = $5,
            avaliacao_registrada_em = $6,
+           protocolo_atendimento = COALESCE(protocolo_atendimento, $7),
            updated_at = NOW()
-       WHERE id = $7
+       WHERE id = $8
        RETURNING *`,
       [
         statusFinal,
@@ -721,6 +813,7 @@ async function updateAgendamento(req, res) {
         notaFinal,
         comentarioFinal || null,
         avaliacaoRegistradaEmFinal,
+        protocoloAtendimento,
         id,
       ]
     );
@@ -744,6 +837,23 @@ async function updateAgendamento(req, res) {
     client = null;
 
     let reviewRequest = null;
+    let rescheduleNotification = null;
+    if (alterouHorario && statusFinal !== 'cancelado') {
+      rescheduleNotification = await enviarRemarcacaoAutomaticaAgendamentoSeguro({
+        barbeariaId: atual.barbearia_id,
+        phoneNumber: atual.cliente_telefone,
+        nomeCliente: atual.cliente_nome,
+        nomeBarbearia: atual.barbearia_nome,
+        enderecoBarbearia: atual.barbearia_endereco,
+        servicoNome: atual.servico_nome || 'Serviço',
+        dataAnterior: dataAtual,
+        horaAnterior: horaAtual,
+        data: dataFinal,
+        hora: horaFinal,
+        protocoloAtendimento: result.rows[0]?.protocolo_atendimento || protocoloAtendimento,
+      });
+    }
+
     if (deveSolicitarAvaliacao) {
       try {
         reviewRequest = await enviarSolicitacaoAvaliacaoConclusao({
@@ -767,7 +877,7 @@ async function updateAgendamento(req, res) {
       }
     }
 
-    res.json({ agendamento: result.rows[0], rating, reviewRequest });
+    res.json({ agendamento: result.rows[0], rating, reviewRequest, rescheduleNotification });
   } catch (error) {
     if (client) {
       try {

--- a/backend/src/routes/internalBotSync.js
+++ b/backend/src/routes/internalBotSync.js
@@ -3,6 +3,10 @@ const config = require('../config');
 const { getBarbeariaSyncPayload } = require('../services/botSync');
 const { ensureAgendamentoSchema } = require('../services/agendamentoSchema');
 const { ensureServicoAvailabilitySchema } = require('../services/servicoAvailability');
+const {
+  gerarProtocoloAtendimentoUnico,
+  normalizarProtocoloAtendimento,
+} = require('../services/appointmentProtocol');
 const pool = require('../config/database');
 
 const router = express.Router();
@@ -69,10 +73,52 @@ function serializarAgendamentoPayload(payload = {}) {
     data: normalizarData(appointment.data),
     hora: normalizarHora(appointment.hora),
     status: text(appointment.status) || 'pendente',
+    protocolo_atendimento: normalizarProtocoloAtendimento(appointment.protocolo_atendimento || appointment.protocoloAtendimento),
     chatbot_session_id: nullableText(appointment.chatbot_session_id || appointment.chatbotSessionId),
     observacoes: nullableText(appointment.observacoes),
     origem: text(appointment.origem) || 'whatsapp',
   };
+}
+
+function phoneVariants(value = '') {
+  const digits = String(value || '').replace(/\D/g, '');
+  if (!digits) return [];
+
+  const variants = new Set([digits]);
+  if (digits.startsWith('55')) {
+    variants.add(digits.slice(2));
+  } else {
+    variants.add(`55${digits}`);
+  }
+
+  return Array.from(variants).filter(Boolean);
+}
+
+function phoneMatches(received = '', stored = '') {
+  const receivedVariants = phoneVariants(received);
+  const storedVariants = phoneVariants(stored);
+  return receivedVariants.length > 0 && storedVariants.some((item) => receivedVariants.includes(item));
+}
+
+async function reservarProtocoloAtendimento({ protocolo, appointmentId }) {
+  const normalized = normalizarProtocoloAtendimento(protocolo);
+
+  if (normalized) {
+    const conflito = await pool.query(
+      `SELECT id
+       FROM agendamentos
+       WHERE protocolo_atendimento = $1
+         AND id != $2
+       LIMIT 1`,
+      [normalized, appointmentId]
+    );
+
+    if (conflito.rows.length === 0) {
+      return normalized;
+    }
+  }
+
+  return gerarProtocoloAtendimentoUnico(pool);
 }
 
 async function normalizarServicoId(servicoId, barbeariaId) {
@@ -217,6 +263,10 @@ router.post('/appointments', async (req, res) => {
     appointment.servico_id = servicoId;
     appointment.cliente_id = clienteId;
     appointment.barbeiro_id = barbeiroId;
+    appointment.protocolo_atendimento = await reservarProtocoloAtendimento({
+      protocolo: appointment.protocolo_atendimento,
+      appointmentId: appointment.id,
+    });
 
     if (appointment.status !== 'cancelado') {
       const conflito = await pool.query(
@@ -254,11 +304,12 @@ router.post('/appointments', async (req, res) => {
          data,
          hora,
          status,
+         protocolo_atendimento,
          chatbot_session_id,
          observacoes,
          origem
        )
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
        ON DUPLICATE KEY UPDATE
          barbearia_id = VALUES(barbearia_id),
          servico_id = VALUES(servico_id),
@@ -271,6 +322,7 @@ router.post('/appointments', async (req, res) => {
          data = VALUES(data),
          hora = VALUES(hora),
          status = VALUES(status),
+         protocolo_atendimento = COALESCE(VALUES(protocolo_atendimento), protocolo_atendimento),
          chatbot_session_id = VALUES(chatbot_session_id),
          observacoes = VALUES(observacoes),
          origem = VALUES(origem),
@@ -288,6 +340,7 @@ router.post('/appointments', async (req, res) => {
         appointment.data,
         appointment.hora,
         appointment.status,
+        appointment.protocolo_atendimento,
         appointment.chatbot_session_id,
         appointment.observacoes,
         appointment.origem,
@@ -319,6 +372,183 @@ router.post('/appointments', async (req, res) => {
     res.status(500).json({
       error: error?.message || 'Não foi possível sincronizar o agendamento do bot.',
       code: 'APPOINTMENT_SYNC_FAILED',
+    });
+  }
+});
+
+router.get('/appointments/protocol/:protocol', async (req, res) => {
+  try {
+    await ensureAgendamentoSchema();
+
+    const protocolo = normalizarProtocoloAtendimento(req.params?.protocol);
+    const barbeariaId = text(req.query?.barbearia_id || req.query?.barbeariaId);
+    const phoneNumber = text(req.query?.phone_number || req.query?.phoneNumber);
+
+    if (!protocolo || !barbeariaId || !phoneNumber) {
+      return res.status(400).json({
+        error: 'Protocolo, barbearia e telefone são obrigatórios.',
+        code: 'INVALID_PROTOCOL_LOOKUP_PAYLOAD',
+      });
+    }
+
+    const result = await pool.query(
+      `SELECT
+         a.*,
+         COALESCE(c.nome, a.cliente_nome_externo, 'Cliente') AS cliente_nome,
+         COALESCE(c.telefone, a.cliente_telefone_externo, '') AS cliente_telefone,
+         COALESCE(a.servico_nome_snapshot, s.nome, NULLIF(a.observacoes, '')) AS servico_nome,
+         COALESCE(a.servico_preco_snapshot, s.preco, 0) AS servico_preco,
+         COALESCE(s.duracao_minutos, 30) AS servico_duracao,
+         b.nome AS barbearia_nome,
+         b.endereco AS barbearia_endereco
+       FROM agendamentos a
+       LEFT JOIN usuarios c ON c.id = a.cliente_id
+       LEFT JOIN servicos s ON s.id = a.servico_id
+       LEFT JOIN barbearias b ON b.id = a.barbearia_id
+       WHERE a.protocolo_atendimento = $1
+         AND a.barbearia_id = $2
+       LIMIT 1`,
+      [protocolo, barbeariaId]
+    );
+
+    const appointment = result.rows[0];
+    if (!appointment || !phoneMatches(phoneNumber, appointment.cliente_telefone)) {
+      return res.status(404).json({
+        error: 'Não encontrei agendamento para este protocolo e telefone.',
+        code: 'APPOINTMENT_PROTOCOL_NOT_FOUND',
+      });
+    }
+
+    if (['cancelado', 'faltou', 'concluido'].includes(String(appointment.status || '').toLowerCase())) {
+      return res.status(409).json({
+        error: 'Este agendamento não está disponível para remarcação pelo WhatsApp.',
+        code: 'APPOINTMENT_NOT_RESCHEDULABLE',
+      });
+    }
+
+    res.json({
+      ok: true,
+      agendamento: appointment,
+    });
+  } catch (error) {
+    console.error('[INTERNAL_BOT_SYNC.protocol] Falha ao buscar agendamento por protocolo', {
+      message: error?.message,
+      code: error?.code,
+    }, error);
+
+    res.status(500).json({
+      error: error?.message || 'Não foi possível buscar o agendamento pelo protocolo.',
+      code: 'APPOINTMENT_PROTOCOL_LOOKUP_FAILED',
+    });
+  }
+});
+
+router.post('/appointments/:id/reschedule', async (req, res) => {
+  try {
+    await ensureAgendamentoSchema();
+
+    const id = text(req.params?.id);
+    const barbeariaId = text(req.body?.barbearia_id || req.body?.barbeariaId);
+    const phoneNumber = text(req.body?.phone_number || req.body?.phoneNumber);
+    const data = normalizarData(req.body?.data);
+    const hora = normalizarHora(req.body?.hora);
+
+    if (!id || !barbeariaId || !phoneNumber || !data || !hora) {
+      return res.status(400).json({
+        error: 'Agendamento, barbearia, telefone, data e hora são obrigatórios.',
+        code: 'INVALID_APPOINTMENT_RESCHEDULE_PAYLOAD',
+      });
+    }
+
+    const atualResult = await pool.query(
+      `SELECT
+         a.*,
+         COALESCE(c.nome, a.cliente_nome_externo, 'Cliente') AS cliente_nome,
+         COALESCE(c.telefone, a.cliente_telefone_externo, '') AS cliente_telefone,
+         COALESCE(a.servico_nome_snapshot, s.nome, NULLIF(a.observacoes, '')) AS servico_nome,
+         COALESCE(a.servico_preco_snapshot, s.preco, 0) AS servico_preco,
+         COALESCE(s.duracao_minutos, 30) AS servico_duracao,
+         b.nome AS barbearia_nome,
+         b.endereco AS barbearia_endereco
+       FROM agendamentos a
+       LEFT JOIN usuarios c ON c.id = a.cliente_id
+       LEFT JOIN servicos s ON s.id = a.servico_id
+       LEFT JOIN barbearias b ON b.id = a.barbearia_id
+       WHERE a.id = $1
+         AND a.barbearia_id = $2
+       LIMIT 1`,
+      [id, barbeariaId]
+    );
+
+    const atual = atualResult.rows[0];
+    if (!atual || !phoneMatches(phoneNumber, atual.cliente_telefone)) {
+      return res.status(404).json({
+        error: 'Agendamento não encontrado para este telefone.',
+        code: 'APPOINTMENT_NOT_FOUND',
+      });
+    }
+
+    if (['cancelado', 'faltou', 'concluido'].includes(String(atual.status || '').toLowerCase())) {
+      return res.status(409).json({
+        error: 'Este agendamento não está disponível para remarcação pelo WhatsApp.',
+        code: 'APPOINTMENT_NOT_RESCHEDULABLE',
+      });
+    }
+
+    const conflito = await pool.query(
+      `SELECT id
+       FROM agendamentos
+       WHERE barbearia_id = $1
+         AND data = $2
+         AND hora = $3
+         AND status != $4
+         AND id != $5
+       LIMIT 1`,
+      [barbeariaId, data, hora, 'cancelado', id]
+    );
+
+    if (conflito.rows.length > 0) {
+      return res.status(409).json({
+        error: 'Horário não disponível na agenda principal.',
+        code: 'TIME_CONFLICT',
+      });
+    }
+
+    const protocoloAtendimento = atual.protocolo_atendimento || await gerarProtocoloAtendimentoUnico(pool);
+    const updateResult = await pool.query(
+      `UPDATE agendamentos
+       SET data = $1,
+           hora = $2,
+           protocolo_atendimento = COALESCE(protocolo_atendimento, $3),
+           updated_at = NOW()
+       WHERE id = $4
+       RETURNING *`,
+      [data, hora, protocoloAtendimento, id]
+    );
+
+    res.json({
+      ok: true,
+      previous: {
+        data: atual.data,
+        hora: atual.hora,
+      },
+      agendamento: {
+        ...atual,
+        ...(updateResult.rows[0] || {}),
+        data,
+        hora,
+        protocolo_atendimento: protocoloAtendimento,
+      },
+    });
+  } catch (error) {
+    console.error('[INTERNAL_BOT_SYNC.reschedule] Falha ao remarcar agendamento pelo bot', {
+      message: error?.message,
+      code: error?.code,
+    }, error);
+
+    res.status(500).json({
+      error: error?.message || 'Não foi possível remarcar o agendamento pelo bot.',
+      code: 'APPOINTMENT_RESCHEDULE_FAILED',
     });
   }
 });

--- a/backend/src/services/agendamentoSchema.js
+++ b/backend/src/services/agendamentoSchema.js
@@ -9,11 +9,17 @@ async function executarGarantiasSchema() {
     ADD COLUMN IF NOT EXISTS cliente_telefone_externo VARCHAR(20),
     ADD COLUMN IF NOT EXISTS origem VARCHAR(30) DEFAULT 'app',
     ADD COLUMN IF NOT EXISTS chatbot_session_id CHAR(36),
+    ADD COLUMN IF NOT EXISTS protocolo_atendimento VARCHAR(20),
     ADD COLUMN IF NOT EXISTS servico_nome_snapshot TEXT,
     ADD COLUMN IF NOT EXISTS servico_preco_snapshot NUMERIC(10,2),
     ADD COLUMN IF NOT EXISTS avaliacao_nota INTEGER,
     ADD COLUMN IF NOT EXISTS avaliacao_comentario TEXT,
     ADD COLUMN IF NOT EXISTS avaliacao_registrada_em DATETIME
+  `);
+
+  await pool.query(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_agendamentos_protocolo_atendimento
+    ON agendamentos (protocolo_atendimento)
   `);
 }
 

--- a/backend/src/services/appointmentProtocol.js
+++ b/backend/src/services/appointmentProtocol.js
@@ -1,0 +1,42 @@
+const crypto = require('crypto');
+const pool = require('../config/database');
+
+const PROTOCOL_MIN = 100000;
+const PROTOCOL_MAX_EXCLUSIVE = 1000000;
+
+function gerarProtocoloAtendimento(random = Math.random) {
+  const value = typeof random === 'function' ? Number(random()) : Math.random();
+  const safeValue = Number.isFinite(value) ? Math.min(Math.max(value, 0), 0.999999999999) : Math.random();
+  return String(Math.floor(safeValue * (PROTOCOL_MAX_EXCLUSIVE - PROTOCOL_MIN)) + PROTOCOL_MIN);
+}
+
+function gerarProtocoloSeguro() {
+  return String(crypto.randomInt(PROTOCOL_MIN, PROTOCOL_MAX_EXCLUSIVE));
+}
+
+function normalizarProtocoloAtendimento(value = '') {
+  const digits = String(value || '').replace(/\D/g, '');
+  return digits.length >= 4 ? digits.slice(0, 20) : '';
+}
+
+async function gerarProtocoloAtendimentoUnico(executor = pool) {
+  for (let tentativa = 0; tentativa < 20; tentativa += 1) {
+    const protocolo = gerarProtocoloSeguro();
+    const existente = await executor.query(
+      'SELECT id FROM agendamentos WHERE protocolo_atendimento = $1 LIMIT 1',
+      [protocolo]
+    );
+
+    if (existente.rows.length === 0) {
+      return protocolo;
+    }
+  }
+
+  throw new Error('Não foi possível gerar um protocolo de atendimento único.');
+}
+
+module.exports = {
+  gerarProtocoloAtendimento,
+  gerarProtocoloAtendimentoUnico,
+  normalizarProtocoloAtendimento,
+};

--- a/backend/src/services/whatsapp.js
+++ b/backend/src/services/whatsapp.js
@@ -22,6 +22,11 @@ class WhatsAppService {
     return `${match[3]}/${match[2]}`;
   }
 
+  static formatarHoraCurta(hora = '') {
+    const match = String(hora || '').match(/(\d{2}):(\d{2})/);
+    return match ? `${match[1]}:${match[2]}` : String(hora || '--:--');
+  }
+
   static formatarTelefone(telefone = '') {
     const numero = this.limparTelefone(telefone);
     if (numero.length === 13) {
@@ -74,19 +79,49 @@ class WhatsAppService {
       nomeBarbearia,
       enderecoBarbearia,
       barbeiroNome,
+      protocoloAtendimento,
     } = dados;
 
     const dataFormatada = this.formatarDataCurtaBR(data);
     const profissional = barbeiroNome ? `\n*Profissional:* ${barbeiroNome}` : '';
     const endereco = enderecoBarbearia ? `\n*Local:* ${enderecoBarbearia}` : '';
+    const protocolo = protocoloAtendimento ? `\n*Protocolo:* ${protocoloAtendimento}` : '';
 
     return `Olá ${nomeCliente || 'cliente'}! Seu agendamento na *${nomeBarbearia || 'barbearia'}* foi confirmado.
 
 *Serviço:* ${servico || 'Serviço agendado'}
 *Data:* ${dataFormatada}
-*Hora:* ${hora || '--:--'}${profissional}${endereco}
+*Hora:* ${this.formatarHoraCurta(hora)}${profissional}${endereco}${protocolo}
 
-Se precisar ajustar ou remarcar, é só responder por aqui.`;
+Se precisar ajustar ou remarcar, é só responder por aqui${protocoloAtendimento ? ` com o protocolo *${protocoloAtendimento}*.` : '.'}`;
+  }
+
+  static templateAgendamentoRemarcadoCliente(dados) {
+    const {
+      nomeCliente,
+      servico,
+      data,
+      hora,
+      dataAnterior,
+      horaAnterior,
+      nomeBarbearia,
+      enderecoBarbearia,
+      barbeiroNome,
+      protocoloAtendimento,
+    } = dados;
+
+    const profissional = barbeiroNome ? `\n*Profissional:* ${barbeiroNome}` : '';
+    const endereco = enderecoBarbearia ? `\n*Local:* ${enderecoBarbearia}` : '';
+    const protocolo = protocoloAtendimento ? `\n*Protocolo:* ${protocoloAtendimento}` : '';
+    const instrucoes = protocoloAtendimento
+      ? `\n\nSe precisar remarcar novamente pelo WhatsApp, responda com o protocolo *${protocoloAtendimento}*.`
+      : '';
+
+    return `Olá ${nomeCliente || 'cliente'}! Seu agendamento na *${nomeBarbearia || 'barbearia'}* foi remarcado.
+
+*Serviço:* ${servico || 'Serviço agendado'}
+*De:* ${this.formatarDataCurtaBR(dataAnterior)} às ${this.formatarHoraCurta(horaAnterior)}
+*Para:* ${this.formatarDataCurtaBR(data)} às ${this.formatarHoraCurta(hora)}${profissional}${endereco}${protocolo}${instrucoes}`;
   }
 
   static templateAgendamentoBarbearia(dados) {
@@ -99,19 +134,21 @@ Se precisar ajustar ou remarcar, é só responder por aqui.`;
       nomeBarbearia,
       enderecoBarbearia,
       barbeiroNome,
+      protocoloAtendimento,
     } = dados;
 
     const dataFormatada = this.formatarDataBR(data);
     const profissional = barbeiroNome ? `\n*Profissional:* ${barbeiroNome}` : '';
     const endereco = enderecoBarbearia ? `\n*Endereço:* ${enderecoBarbearia}` : '';
     const telefone = telefoneCliente ? `\n*Telefone cliente:* ${this.formatarTelefone(telefoneCliente)}` : '';
+    const protocolo = protocoloAtendimento ? `\n*Protocolo:* ${protocoloAtendimento}` : '';
 
     return `Novo agendamento pelo site na *${nomeBarbearia || 'barbearia'}*.
 
 *Cliente:* ${nomeCliente || 'Cliente'}${telefone}
 *Serviço:* ${servico || 'Serviço agendado'}
 *Data:* ${dataFormatada}
-*Hora:* ${hora || '--:--'}${profissional}${endereco}
+*Hora:* ${this.formatarHoraCurta(hora)}${profissional}${endereco}${protocolo}
 
 Origem: site`;
   }

--- a/backend/tests/appointment-protocol.test.js
+++ b/backend/tests/appointment-protocol.test.js
@@ -1,0 +1,44 @@
+process.env.DATABASE_SKIP_INIT = 'true';
+
+const WhatsAppService = require('../src/services/whatsapp');
+const {
+  gerarProtocoloAtendimento,
+  normalizarProtocoloAtendimento,
+} = require('../src/services/appointmentProtocol');
+const pool = require('../src/config/database');
+
+describe('protocolo de atendimento de agendamentos', () => {
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('gera protocolo numerico de 6 digitos', () => {
+    expect(gerarProtocoloAtendimento(() => 0)).toBe('100000');
+    expect(gerarProtocoloAtendimento(() => 0.999999)).toBe('999999');
+  });
+
+  it('normaliza protocolo digitado pelo cliente', () => {
+    expect(normalizarProtocoloAtendimento('Protocolo 483-921')).toBe('483921');
+    expect(normalizarProtocoloAtendimento('abc')).toBe('');
+  });
+
+  it('monta mensagem de remarcacao com protocolo e horario antigo/novo', () => {
+    const mensagem = WhatsAppService.templateAgendamentoRemarcadoCliente({
+      nomeCliente: 'Pablo',
+      nomeBarbearia: 'BarbeariaDoET',
+      servico: 'Corte Careca',
+      protocoloAtendimento: '483921',
+      dataAnterior: '2026-05-20',
+      horaAnterior: '17:00',
+      data: '2026-05-20',
+      hora: '09:00',
+      enderecoBarbearia: 'Rua Teste, 123',
+    });
+
+    expect(mensagem).toContain('foi remarcado');
+    expect(mensagem).toContain('*Protocolo:* 483921');
+    expect(mensagem).toContain('*De:* 20/05 às 17:00');
+    expect(mensagem).toContain('*Para:* 20/05 às 09:00');
+    expect(mensagem).toContain('responda com o protocolo *483921*');
+  });
+});

--- a/backend/tests/bot-appointment-protocol.test.js
+++ b/backend/tests/bot-appointment-protocol.test.js
@@ -1,0 +1,22 @@
+process.env.DATABASE_SKIP_INIT = 'true';
+
+const { serializarAgendamento } = require('../../bot/src/services/backendAppointments');
+const pool = require('../../bot/src/config/database');
+
+describe('sincronizacao de protocolo entre bot e API principal', () => {
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('envia o protocolo_atendimento no payload sincronizado pelo bot', () => {
+    const payload = serializarAgendamento({
+      id: 'agendamento-1',
+      barbearia_id: 'barbearia-1',
+      data: '2026-05-20',
+      hora: '09:00',
+      protocoloAtendimento: '483921',
+    });
+
+    expect(payload.protocolo_atendimento).toBe('483921');
+  });
+});

--- a/bot/src/services/agendamentoSchema.js
+++ b/bot/src/services/agendamentoSchema.js
@@ -31,6 +31,7 @@ async function executarGarantiasSchema() {
       data DATE NOT NULL,
       hora TIME NOT NULL,
       status VARCHAR(20) DEFAULT 'pendente',
+      protocolo_atendimento VARCHAR(20),
       chatbot_session_id CHAR(36),
       servico_nome_snapshot TEXT,
       servico_preco_snapshot NUMERIC(10,2),
@@ -60,6 +61,7 @@ async function executarGarantiasSchema() {
     ADD COLUMN IF NOT EXISTS cliente_telefone_externo VARCHAR(20),
     ADD COLUMN IF NOT EXISTS origem VARCHAR(30) DEFAULT 'app',
     ADD COLUMN IF NOT EXISTS chatbot_session_id CHAR(36),
+    ADD COLUMN IF NOT EXISTS protocolo_atendimento VARCHAR(20),
     ADD COLUMN IF NOT EXISTS servico_nome_snapshot TEXT,
     ADD COLUMN IF NOT EXISTS servico_preco_snapshot NUMERIC(10,2),
     ADD COLUMN IF NOT EXISTS avaliacao_nota INTEGER,
@@ -68,6 +70,11 @@ async function executarGarantiasSchema() {
     ADD COLUMN IF NOT EXISTS backend_sync_status VARCHAR(30) DEFAULT 'pending',
     ADD COLUMN IF NOT EXISTS backend_sync_error TEXT,
     ADD COLUMN IF NOT EXISTS backend_synced_at DATETIME
+  `);
+
+  await pool.query(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_agendamentos_protocolo_atendimento
+    ON agendamentos (protocolo_atendimento)
   `);
 }
 

--- a/bot/src/services/appointmentProtocol.js
+++ b/bot/src/services/appointmentProtocol.js
@@ -1,0 +1,18 @@
+const crypto = require('crypto');
+
+const PROTOCOL_MIN = 100000;
+const PROTOCOL_MAX_EXCLUSIVE = 1000000;
+
+function gerarProtocoloAtendimento() {
+  return String(crypto.randomInt(PROTOCOL_MIN, PROTOCOL_MAX_EXCLUSIVE));
+}
+
+function normalizarProtocoloAtendimento(value = '') {
+  const digits = String(value || '').replace(/\D/g, '');
+  return digits.length >= 4 ? digits.slice(0, 20) : '';
+}
+
+module.exports = {
+  gerarProtocoloAtendimento,
+  normalizarProtocoloAtendimento,
+};

--- a/bot/src/services/backendAppointments.js
+++ b/bot/src/services/backendAppointments.js
@@ -24,6 +24,49 @@ function normalizarHora(valor = '') {
   return `${match[1]}:${match[2]}:${match[3] || '00'}`;
 }
 
+async function requestBackend(path, { method = 'GET', body } = {}) {
+  if (!config.backendSync.enabled) {
+    const error = new Error('Sincronização com a API principal desativada.');
+    error.code = 'BACKEND_SYNC_DISABLED';
+    throw error;
+  }
+
+  if (!config.botServiceToken) {
+    const error = new Error('BOT_SERVICE_TOKEN não configurado no bot.');
+    error.code = 'BOT_SERVICE_TOKEN_NOT_CONFIGURED';
+    throw error;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), config.backendSync.timeoutMs);
+
+  try {
+    const response = await fetch(`${config.backendSync.apiUrl}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${config.botServiceToken}`,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: body ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    });
+
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const error = new Error(payload?.error || 'Falha ao comunicar com a API principal.');
+      error.code = payload?.code || 'BACKEND_REQUEST_FAILED';
+      error.status = response.status;
+      error.payload = payload;
+      throw error;
+    }
+
+    return payload;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 function serializarAgendamento(agendamento = {}) {
   return {
     id: normalizarTexto(agendamento.id),
@@ -38,6 +81,7 @@ function serializarAgendamento(agendamento = {}) {
     data: normalizarData(agendamento.data),
     hora: normalizarHora(agendamento.hora),
     status: normalizarTexto(agendamento.status) || 'pendente',
+    protocolo_atendimento: normalizarTexto(agendamento.protocolo_atendimento || agendamento.protocoloAtendimento),
     chatbot_session_id: normalizarTexto(agendamento.chatbot_session_id || agendamento.chatbotSessionId),
     observacoes: normalizarTexto(agendamento.observacoes),
     origem: normalizarTexto(agendamento.origem) || 'whatsapp',
@@ -64,34 +108,53 @@ async function syncAppointmentToBackend(agendamento = {}) {
     throw error;
   }
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), config.backendSync.timeoutMs);
+  return requestBackend('/internal/bot/appointments', {
+    method: 'POST',
+    body: { appointment },
+  });
+}
 
-  try {
-    const response = await fetch(`${config.backendSync.apiUrl}/internal/bot/appointments`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${config.botServiceToken}`,
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ appointment }),
-      signal: controller.signal,
-    });
+async function fetchAppointmentByProtocol({ protocolo, barbeariaId, phoneNumber } = {}) {
+  const normalizedProtocol = normalizarTexto(protocolo).replace(/\D/g, '');
+  const normalizedBarbeariaId = normalizarTexto(barbeariaId);
+  const normalizedPhone = normalizarTexto(phoneNumber);
 
-    const payload = await response.json().catch(() => ({}));
-    if (!response.ok) {
-      const error = new Error(payload?.error || 'Falha ao sincronizar agendamento com a API principal.');
-      error.code = payload?.code || 'BACKEND_APPOINTMENT_SYNC_FAILED';
-      error.status = response.status;
-      error.payload = payload;
-      throw error;
-    }
-
-    return payload;
-  } finally {
-    clearTimeout(timeout);
+  if (!normalizedProtocol || !normalizedBarbeariaId || !normalizedPhone) {
+    const error = new Error('Protocolo, barbearia e telefone são obrigatórios.');
+    error.code = 'INVALID_PROTOCOL_LOOKUP_PAYLOAD';
+    throw error;
   }
+
+  const params = new URLSearchParams({
+    barbearia_id: normalizedBarbeariaId,
+    phone_number: normalizedPhone,
+  });
+
+  return requestBackend(`/internal/bot/appointments/protocol/${encodeURIComponent(normalizedProtocol)}?${params.toString()}`);
+}
+
+async function rescheduleAppointmentInBackend({ appointmentId, barbeariaId, phoneNumber, data, hora } = {}) {
+  const normalizedAppointmentId = normalizarTexto(appointmentId);
+  const normalizedBarbeariaId = normalizarTexto(barbeariaId);
+  const normalizedPhone = normalizarTexto(phoneNumber);
+  const normalizedData = normalizarData(data);
+  const normalizedHora = normalizarHora(hora);
+
+  if (!normalizedAppointmentId || !normalizedBarbeariaId || !normalizedPhone || !normalizedData || !normalizedHora) {
+    const error = new Error('Agendamento, barbearia, telefone, data e hora são obrigatórios.');
+    error.code = 'INVALID_APPOINTMENT_RESCHEDULE_PAYLOAD';
+    throw error;
+  }
+
+  return requestBackend(`/internal/bot/appointments/${encodeURIComponent(normalizedAppointmentId)}/reschedule`, {
+    method: 'POST',
+    body: {
+      barbearia_id: normalizedBarbeariaId,
+      phone_number: normalizedPhone,
+      data: normalizedData,
+      hora: normalizedHora,
+    },
+  });
 }
 
 async function markAppointmentBackendSyncStatus(appointmentId, status, errorMessage = '') {
@@ -143,6 +206,7 @@ async function syncPendingAppointmentsToBackend({ limit = 50 } = {}) {
        data,
        hora,
        status,
+       protocolo_atendimento,
        chatbot_session_id,
        observacoes,
        origem
@@ -201,6 +265,8 @@ async function syncPendingAppointmentsToBackend({ limit = 50 } = {}) {
 module.exports = {
   serializarAgendamento,
   syncAppointmentToBackend,
+  fetchAppointmentByProtocol,
+  rescheduleAppointmentInBackend,
   markAppointmentBackendSyncStatus,
   syncPendingAppointmentsToBackend,
 };

--- a/bot/src/services/chatbotConversation.js
+++ b/bot/src/services/chatbotConversation.js
@@ -5,7 +5,13 @@ const { registrarAvaliacaoAtendimento, normalizarAvaliacaoNota } = require('./ba
 const {
   markAppointmentBackendSyncStatus,
   syncAppointmentToBackend,
+  fetchAppointmentByProtocol,
+  rescheduleAppointmentInBackend,
 } = require('./backendAppointments');
+const {
+  gerarProtocoloAtendimento,
+  normalizarProtocoloAtendimento,
+} = require('./appointmentProtocol');
 const {
   ensureChatbotTrainingSchema,
   getChatbotOperationalSettings,
@@ -110,6 +116,39 @@ function minutosParaHora(totalMinutos) {
 function normalizarHora(valor, fallback = '') {
   const texto = String(valor || '').trim().slice(0, 5);
   return /^\d{2}:\d{2}$/.test(texto) ? texto : fallback;
+}
+
+function normalizarDataISOValor(valor = '') {
+  if (valor instanceof Date && !Number.isNaN(valor.getTime())) {
+    const ano = valor.getUTCFullYear();
+    const mes = String(valor.getUTCMonth() + 1).padStart(2, '0');
+    const dia = String(valor.getUTCDate()).padStart(2, '0');
+    return `${ano}-${mes}-${dia}`;
+  }
+
+  const match = String(valor || '').match(/\d{4}-\d{2}-\d{2}/);
+  return match ? match[0] : String(valor || '').trim();
+}
+
+function extrairProtocoloMensagem(texto = '') {
+  const protocolo = normalizarProtocoloAtendimento(texto);
+  return protocolo.length === 6 ? protocolo : '';
+}
+
+async function gerarProtocoloLocalUnico() {
+  for (let tentativa = 0; tentativa < 20; tentativa += 1) {
+    const protocolo = gerarProtocoloAtendimento();
+    const existente = await pool.query(
+      'SELECT id FROM agendamentos WHERE protocolo_atendimento = $1 LIMIT 1',
+      [protocolo]
+    );
+
+    if (existente.rows.length === 0) {
+      return protocolo;
+    }
+  }
+
+  throw new Error('Não foi possível gerar um protocolo de atendimento único.');
 }
 
 function gerarHorariosIntervalo(inicio, fim, intervaloMinutos = 30) {
@@ -788,7 +827,7 @@ function montarMensagemConfirmacao({ nomeContato, nomeServico, dataISO, hora, du
   return `Só confirmando os detalhes do seu agendamento:\n\n*Nome:* ${nomeContato}\n*Serviço:* ${nomeServico}${duracao}${preco}\n*Data:* ${formatarDataCurtaBR(dataISO)}\n*Hora:* ${hora}${endereco}\n\nSe estiver tudo certo, responda *1* para confirmar.\nSe quiser escolher outro horário, responda *2*.`;
 }
 
-async function listarHorariosDisponiveis(barbearia, servico, dataISO) {
+async function listarHorariosDisponiveis(barbearia, servico, dataISO, options = {}) {
   const aberturaPadrao = normalizarHora(barbearia?.horario_abertura, '09:00');
   const fechamentoPadrao = normalizarHora(barbearia?.horario_fechamento, '18:00');
   const horariosSemana = Array.isArray(barbearia?.horarios_semana) ? barbearia.horarios_semana : [];
@@ -802,15 +841,20 @@ async function listarHorariosDisponiveis(barbearia, servico, dataISO) {
   const duracaoServico = Number(servico?.duracao || 30);
   const fechamentoMin = horaParaMinutos(faixa.fechamento);
 
-  const agendamentosResult = await pool.query(
-    `SELECT a.hora, COALESCE(s.duracao_minutos, 30) AS duracao_minutos
+  const params = [barbearia.id, dataISO];
+  let query = `SELECT a.hora, COALESCE(s.duracao_minutos, 30) AS duracao_minutos
      FROM agendamentos a
      LEFT JOIN servicos s ON s.id = a.servico_id
      WHERE a.barbearia_id = $1
        AND a.data = $2
-       AND a.status NOT IN ('cancelado', 'faltou')`,
-    [barbearia.id, dataISO]
-  );
+       AND a.status NOT IN ('cancelado', 'faltou')`;
+
+  if (options.ignoreAppointmentId) {
+    params.push(String(options.ignoreAppointmentId));
+    query += ` AND a.id <> $${params.length}`;
+  }
+
+  const agendamentosResult = await pool.query(query, params);
 
   const ocupados = agendamentosResult.rows
     .map((item) => {
@@ -905,12 +949,13 @@ async function criarAgendamentoExterno({
        data,
        hora,
        status,
+       protocolo_atendimento,
        chatbot_session_id,
        observacoes,
        origem,
        backend_sync_status
       )
-     VALUES ($1, $2, $3, $4, NULL, $5, $6, $7, $8, 'pendente', $9, $10, 'whatsapp', 'pending')
+     VALUES ($1, $2, $3, $4, NULL, $5, $6, $7, $8, 'pendente', $9, $10, $11, 'whatsapp', 'pending')
       RETURNING *`,
     [
       barbeariaId,
@@ -921,6 +966,7 @@ async function criarAgendamentoExterno({
       telefoneContato,
       dataISO,
       hora,
+      await gerarProtocoloLocalUnico(),
       sessionId || null,
       'Agendado automaticamente pelo WhatsApp',
     ]
@@ -982,6 +1028,185 @@ async function criarAgendamentoExterno({
     created: true,
     agendamento,
   };
+}
+
+function montarServicoAgendamento(agendamento = {}) {
+  return {
+    id: String(agendamento.servico_id || agendamento.servicoId || ''),
+    nome: String(agendamento.servico_nome || agendamento.servico_nome_snapshot || 'Serviço'),
+    preco: Number(agendamento.servico_preco || agendamento.servico_preco_snapshot || 0),
+    duracao: Number(agendamento.servico_duracao || agendamento.duracao_minutos || 30),
+  };
+}
+
+function montarMensagemAgendamentoDoProtocolo(agendamento = {}) {
+  const protocolo = agendamento.protocolo_atendimento || agendamento.protocoloAtendimento || '';
+  const servico = montarServicoAgendamento(agendamento);
+
+  return `Encontrei seu agendamento pelo protocolo *${protocolo}*.
+
+*Cliente:* ${agendamento.cliente_nome || 'Cliente'}
+*Serviço:* ${servico.nome}
+*Data atual:* ${formatarDataCurtaBR(agendamento.data)}
+*Hora atual:* ${normalizarHora(agendamento.hora, String(agendamento.hora || '').slice(0, 5))}
+
+Para remarcar, me envie a nova data no formato *DD/MM*.
+Exemplo: *25/05*.
+
+Se preferir atendimento manual, responda *atendente*.`;
+}
+
+function montarMensagemConfirmacaoRemarcacao({ agendamento, dataISO, hora, barbearia }) {
+  const servico = montarServicoAgendamento(agendamento);
+
+  return `Só confirmando a remarcação do protocolo *${agendamento.protocolo_atendimento || ''}*:
+
+*Serviço:* ${servico.nome}
+*De:* ${formatarDataCurtaBR(agendamento.data)} às ${normalizarHora(agendamento.hora, String(agendamento.hora || '').slice(0, 5))}
+*Para:* ${formatarDataCurtaBR(dataISO)} às ${hora}
+${barbearia?.endereco ? `*Local:* ${barbearia.endereco}\n` : ''}
+Se estiver tudo certo, responda *1* para confirmar.
+Se quiser escolher outro horário, responda *2*.`.replace(/\n{3,}/g, '\n\n');
+}
+
+async function upsertAgendamentoLocalFromBackend(agendamento = {}, sessionId = null) {
+  if (!agendamento?.id || !agendamento?.barbearia_id || !agendamento?.data || !agendamento?.hora) {
+    return;
+  }
+
+  await pool.query(
+    `INSERT INTO agendamentos (
+       id,
+       barbearia_id,
+       servico_id,
+       servico_nome_snapshot,
+       servico_preco_snapshot,
+       cliente_id,
+       cliente_nome_externo,
+       cliente_telefone_externo,
+       barbeiro_id,
+       data,
+       hora,
+       status,
+       protocolo_atendimento,
+       chatbot_session_id,
+       observacoes,
+       origem,
+       backend_sync_status,
+       backend_synced_at
+     )
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,'whatsapp','synced',CURRENT_TIMESTAMP)
+     ON DUPLICATE KEY UPDATE
+       barbearia_id = VALUES(barbearia_id),
+       servico_id = VALUES(servico_id),
+       servico_nome_snapshot = VALUES(servico_nome_snapshot),
+       servico_preco_snapshot = VALUES(servico_preco_snapshot),
+       cliente_id = VALUES(cliente_id),
+       cliente_nome_externo = VALUES(cliente_nome_externo),
+       cliente_telefone_externo = VALUES(cliente_telefone_externo),
+       barbeiro_id = VALUES(barbeiro_id),
+       data = VALUES(data),
+       hora = VALUES(hora),
+       status = VALUES(status),
+       protocolo_atendimento = COALESCE(VALUES(protocolo_atendimento), protocolo_atendimento),
+       chatbot_session_id = COALESCE(VALUES(chatbot_session_id), chatbot_session_id),
+       observacoes = VALUES(observacoes),
+       backend_sync_status = 'synced',
+       backend_sync_error = NULL,
+       backend_synced_at = CURRENT_TIMESTAMP,
+       updated_at = CURRENT_TIMESTAMP`,
+    [
+      agendamento.id,
+      agendamento.barbearia_id,
+      agendamento.servico_id || null,
+      agendamento.servico_nome || agendamento.servico_nome_snapshot || null,
+      Number(agendamento.servico_preco || agendamento.servico_preco_snapshot || 0),
+      agendamento.cliente_id || null,
+      agendamento.cliente_nome || agendamento.cliente_nome_externo || null,
+      agendamento.cliente_telefone || agendamento.cliente_telefone_externo || null,
+      agendamento.barbeiro_id || null,
+      normalizarDataISOValor(agendamento.data),
+      normalizarHora(agendamento.hora, String(agendamento.hora || '').slice(0, 5)),
+      agendamento.status || 'pendente',
+      agendamento.protocolo_atendimento || null,
+      sessionId || agendamento.chatbot_session_id || null,
+      agendamento.observacoes || 'Sincronizado da agenda principal pelo protocolo de atendimento.',
+    ]
+  );
+}
+
+async function iniciarRemarcacaoPorProtocolo({
+  protocolo,
+  barbearia,
+  telefone,
+  pushName,
+  sessionId,
+  sendReply,
+  salvarEstado,
+}) {
+  try {
+    const response = await fetchAppointmentByProtocol({
+      protocolo,
+      barbeariaId: barbearia.id,
+      phoneNumber: telefone,
+    });
+
+    const agendamento = response?.agendamento;
+    if (!agendamento) {
+      throw new Error('Agendamento não encontrado para este protocolo.');
+    }
+
+    await upsertAgendamentoLocalFromBackend(agendamento, sessionId).catch(() => undefined);
+
+    const mensagem = montarMensagemAgendamentoDoProtocolo(agendamento);
+    await responder(sendReply, mensagem, (patch) => salvarEstado({
+      contactName: agendamento.cliente_nome || capitalizarNome(pushName || '') || 'Cliente',
+      stage: 'awaiting_reschedule_date',
+      replacePayload: true,
+      payload: {
+        rescheduleAppointment: {
+          id: agendamento.id,
+          protocoloAtendimento: agendamento.protocolo_atendimento || protocolo,
+          clienteNome: agendamento.cliente_nome || '',
+          clienteTelefone: agendamento.cliente_telefone || telefone,
+          servicoId: agendamento.servico_id || '',
+          servicoNome: agendamento.servico_nome || agendamento.servico_nome_snapshot || 'Serviço',
+          servicoPreco: Number(agendamento.servico_preco || agendamento.servico_preco_snapshot || 0),
+          servicoDuracao: Number(agendamento.servico_duracao || agendamento.duracao_minutos || 30),
+          dataAtual: normalizarDataISOValor(agendamento.data),
+          horaAtual: normalizarHora(agendamento.hora, String(agendamento.hora || '').slice(0, 5)),
+        },
+      },
+      ...patch,
+    }), {
+      stageBefore: 'idle',
+      stageAfter: 'awaiting_reschedule_date',
+      detectedIntent: 'reschedule_by_protocol',
+      resultCode: 'RESCHEDULE_PROTOCOL_FOUND',
+      slots: { protocoloAtendimento: protocolo },
+    });
+
+    return true;
+  } catch (error) {
+    const mensagem = error?.code === 'APPOINTMENT_NOT_RESCHEDULABLE'
+      ? `Encontrei o protocolo *${protocolo}*, mas esse agendamento não está disponível para remarcação automática.\n\nFale com a equipe da *${barbearia.nome}* para ajustar esse horário.`
+      : `Não encontrei nenhum agendamento ativo para o protocolo *${protocolo}* neste WhatsApp.\n\nConfira o número e envie novamente, ou responda *agendar* para começar um novo agendamento.`;
+
+    await responder(sendReply, mensagem, (patch) => salvarEstado({
+      stage: 'completed',
+      replacePayload: true,
+      payload: {},
+      ...patch,
+    }), {
+      stageBefore: 'idle',
+      stageAfter: 'completed',
+      detectedIntent: 'reschedule_by_protocol',
+      resultCode: error?.code || 'RESCHEDULE_PROTOCOL_NOT_FOUND',
+      slots: { protocoloAtendimento: protocolo },
+    });
+
+    return true;
+  }
 }
 
 async function responder(sendReply, message, saveState, replyMeta = {}) {
@@ -1274,6 +1499,7 @@ async function handleIncomingMessage({ barbeariaId, phoneNumber, message, pushNa
       HUMAN_HANDOFF: 'HUMAN_HANDOFF',
       CANCEL_FLOW: 'CANCEL_FLOW',
       BOOKED: 'BOOKED',
+      RESCHEDULED: 'RESCHEDULED',
       REVIEW_CAPTURED: 'REVIEW_CAPTURED',
     };
 
@@ -1286,12 +1512,31 @@ async function handleIncomingMessage({ barbeariaId, phoneNumber, message, pushNa
     }).catch(() => undefined);
   });
 
+  const salvarEstado = (patch = {}) => saveConversation(barbearia.id, telefone, {
+    ...patch,
+    lastInboundMessage: texto,
+  });
+
   if (conversa?.stage === 'human_handoff' && !RESET_KEYWORDS.includes(textoNormalizado)) {
     await updateChatbotSessionState({
       sessionId: session?.id,
       currentStage: 'human_handoff',
       status: 'human_handoff',
     }).catch(() => undefined);
+    return;
+  }
+
+  const protocoloDigitado = extrairProtocoloMensagem(texto);
+  if (protocoloDigitado && !RESET_KEYWORDS.includes(textoNormalizado)) {
+    await iniciarRemarcacaoPorProtocolo({
+      protocolo: protocoloDigitado,
+      barbearia,
+      telefone,
+      pushName,
+      sessionId: session?.id,
+      sendReply: sendReplyWithTelemetry,
+      salvarEstado,
+    });
     return;
   }
 
@@ -1361,11 +1606,6 @@ async function handleIncomingMessage({ barbeariaId, phoneNumber, message, pushNa
     return;
   }
 
-  const salvarEstado = (patch = {}) => saveConversation(barbearia.id, telefone, {
-    ...patch,
-    lastInboundMessage: texto,
-  });
-
   if (conversa?.payload) {
     const servicoEncontrado = servicosAnalise.length > 0
       ? (analysis?.slots?.desiredServiceId
@@ -1392,6 +1632,249 @@ async function handleIncomingMessage({ barbeariaId, phoneNumber, message, pushNa
   }
 
   switch (conversa.stage) {
+    case 'awaiting_reschedule_date': {
+      const agendamento = conversa.payload?.rescheduleAppointment;
+      if (!agendamento?.id) {
+        await iniciarFluxo({
+          barbearia,
+          phoneNumber: telefone,
+          pushName,
+          sendReply: sendReplyWithTelemetry,
+          sessionId: session?.id,
+          detectedIntent: analysis.globalIntent,
+        });
+        return;
+      }
+
+      const dataISO = parseDateInput(texto);
+      if (!dataISO) {
+        const mensagem = `Não entendi a nova data.\n\nEnvie no formato *DD/MM*.\nExemplo: *25/05*.`;
+        await responder(sendReplyWithTelemetry, mensagem, salvarEstado, {
+          stageBefore: 'awaiting_reschedule_date',
+          stageAfter: 'awaiting_reschedule_date',
+          resultCode: 'RESCHEDULE_DATE_INVALID',
+        });
+        return;
+      }
+
+      const servico = {
+        id: String(agendamento.servicoId || ''),
+        nome: String(agendamento.servicoNome || 'Serviço'),
+        duracao: Number(agendamento.servicoDuracao || 30),
+      };
+      const horarios = await listarHorariosDisponiveis(barbearia, servico, dataISO, {
+        ignoreAppointmentId: agendamento.id,
+      });
+
+      if (horarios.length === 0) {
+        const sugestoes = await sugerirProximasDatasDisponiveis(barbearia, servico, dataISO, 3);
+        const listaSugestoes = sugestoes
+          .map((item) => `- ${formatarDataCurtaBR(item.dataISO)}${item.horarios?.[0] ? ` a partir de ${item.horarios[0]}` : ''}`)
+          .join('\n');
+        const mensagem = sugestoes.length > 0
+          ? `Não encontrei horários livres para remarcar em *${formatarDataCurtaBR(dataISO)}*.\n\nPróximas opções:\n${listaSugestoes}\n\nMe envie outra data no formato *DD/MM*.`
+          : `Não encontrei horários livres para remarcar nessa data.\n\nMe envie outra data no formato *DD/MM*.`;
+
+        await responder(sendReplyWithTelemetry, mensagem, (patch) => salvarEstado({
+          payload: {
+            ...conversa.payload,
+            rescheduleAvailableSlots: [],
+          },
+          ...patch,
+        }), {
+          stageBefore: 'awaiting_reschedule_date',
+          stageAfter: 'awaiting_reschedule_date',
+          resultCode: 'RESCHEDULE_DATE_NO_SLOTS',
+        });
+        return;
+      }
+
+      const mensagem = montarMensagemHorarios(dataISO, horarios);
+      await responder(sendReplyWithTelemetry, mensagem, (patch) => salvarEstado({
+        stage: 'awaiting_reschedule_time',
+        payload: {
+          ...conversa.payload,
+          rescheduleSelectedDate: dataISO,
+          rescheduleAvailableSlots: horarios,
+        },
+        ...patch,
+      }), {
+        stageBefore: 'awaiting_reschedule_date',
+        stageAfter: 'awaiting_reschedule_time',
+        resultCode: 'RESCHEDULE_DATE_SELECTED',
+      });
+      return;
+    }
+
+    case 'awaiting_reschedule_time': {
+      const agendamento = conversa.payload?.rescheduleAppointment;
+      const availableSlots = Array.isArray(conversa.payload?.rescheduleAvailableSlots)
+        ? conversa.payload.rescheduleAvailableSlots.map((horaItem) => ({ hora: horaItem, label: horaItem }))
+        : [];
+      const selecionado = parseOptionSelection(texto, availableSlots);
+
+      if (!agendamento?.id || !selecionado) {
+        const mensagem = `Não consegui identificar o horário desejado.\n\n${montarMensagemHorarios(conversa.payload?.rescheduleSelectedDate, availableSlots.map((item) => item.hora))}`;
+        await responder(sendReplyWithTelemetry, mensagem, salvarEstado, {
+          stageBefore: 'awaiting_reschedule_time',
+          stageAfter: 'awaiting_reschedule_time',
+          resultCode: 'RESCHEDULE_TIME_INVALID',
+        });
+        return;
+      }
+
+      const horaEscolhida = selecionado.hora;
+      const mensagem = montarMensagemConfirmacaoRemarcacao({
+        agendamento: {
+          ...agendamento,
+          data: agendamento.dataAtual,
+          hora: agendamento.horaAtual,
+          protocolo_atendimento: agendamento.protocoloAtendimento,
+          servico_nome: agendamento.servicoNome,
+          servico_preco: agendamento.servicoPreco,
+          servico_duracao: agendamento.servicoDuracao,
+        },
+        dataISO: conversa.payload?.rescheduleSelectedDate || '',
+        hora: horaEscolhida,
+        barbearia,
+      });
+
+      await responder(sendReplyWithTelemetry, mensagem, (patch) => salvarEstado({
+        stage: 'awaiting_reschedule_confirmation',
+        payload: {
+          ...conversa.payload,
+          rescheduleSelectedTime: horaEscolhida,
+        },
+        ...patch,
+      }), {
+        stageBefore: 'awaiting_reschedule_time',
+        stageAfter: 'awaiting_reschedule_confirmation',
+        resultCode: 'RESCHEDULE_TIME_SELECTED',
+      });
+      return;
+    }
+
+    case 'awaiting_reschedule_confirmation': {
+      const agendamento = conversa.payload?.rescheduleAppointment;
+      const dataISO = String(conversa.payload?.rescheduleSelectedDate || '');
+      const hora = String(conversa.payload?.rescheduleSelectedTime || '');
+
+      if (CHANGE_KEYWORDS.includes(textoNormalizado)) {
+        const horarios = Array.isArray(conversa.payload?.rescheduleAvailableSlots)
+          ? conversa.payload.rescheduleAvailableSlots
+          : [];
+        const mensagem = montarMensagemHorarios(dataISO, horarios);
+
+        await responder(sendReplyWithTelemetry, mensagem, (patch) => salvarEstado({
+          stage: 'awaiting_reschedule_time',
+          ...patch,
+        }), {
+          stageBefore: 'awaiting_reschedule_confirmation',
+          stageAfter: 'awaiting_reschedule_time',
+          resultCode: 'RESCHEDULE_CHANGE_TIME',
+        });
+        return;
+      }
+
+      if (!agendamento?.id || !CONFIRM_KEYWORDS.includes(textoNormalizado)) {
+        const mensagem = `Para remarcar, responda com *1* para confirmar ou *2* para escolher outro horário.`;
+        await responder(sendReplyWithTelemetry, mensagem, salvarEstado, {
+          stageBefore: 'awaiting_reschedule_confirmation',
+          stageAfter: 'awaiting_reschedule_confirmation',
+          resultCode: 'RESCHEDULE_CONFIRMATION_INVALID',
+        });
+        return;
+      }
+
+      try {
+        const remarcacao = await rescheduleAppointmentInBackend({
+          appointmentId: agendamento.id,
+          barbeariaId: barbearia.id,
+          phoneNumber: telefone,
+          data: dataISO,
+          hora,
+        });
+
+        const agendamentoAtualizado = remarcacao?.agendamento || {
+          ...agendamento,
+          barbearia_id: barbearia.id,
+          data: dataISO,
+          hora,
+          protocolo_atendimento: agendamento.protocoloAtendimento,
+        };
+
+        await upsertAgendamentoLocalFromBackend(agendamentoAtualizado, session?.id).catch(() => undefined);
+
+        const mensagem = WhatsAppService.templateAgendamentoRemarcadoCliente({
+          nomeCliente: agendamento.clienteNome || conversa.contact_name || pushName || 'cliente',
+          nomeBarbearia: barbearia.nome,
+          servico: agendamento.servicoNome || 'Serviço',
+          dataAnterior: remarcacao?.previous?.data || agendamento.dataAtual,
+          horaAnterior: remarcacao?.previous?.hora || agendamento.horaAtual,
+          data: dataISO,
+          hora,
+          enderecoBarbearia: barbearia.endereco,
+          protocoloAtendimento: agendamento.protocoloAtendimento,
+        });
+
+        await responder(sendReplyWithTelemetry, mensagem, (patch) => salvarEstado({
+          stage: 'completed',
+          replacePayload: true,
+          payload: {
+            ultimoAgendamentoId: agendamento.id,
+            ultimoProtocoloAtendimento: agendamento.protocoloAtendimento,
+          },
+          ...patch,
+        }), {
+          stageBefore: 'awaiting_reschedule_confirmation',
+          stageAfter: 'completed',
+          resultCode: 'RESCHEDULED',
+          slots: {
+            protocoloAtendimento: agendamento.protocoloAtendimento,
+            desiredDate: dataISO,
+            desiredTime: hora,
+          },
+        });
+        return;
+      } catch (error) {
+        if (error?.code === 'TIME_CONFLICT') {
+          const servico = {
+            id: String(agendamento.servicoId || ''),
+            nome: String(agendamento.servicoNome || 'Serviço'),
+            duracao: Number(agendamento.servicoDuracao || 30),
+          };
+          const horariosAtualizados = await listarHorariosDisponiveis(barbearia, servico, dataISO, {
+            ignoreAppointmentId: agendamento.id,
+          });
+          const mensagem = horariosAtualizados.length > 0
+            ? `Esse horário acabou de ficar indisponível na agenda principal.\n\n${montarMensagemHorarios(dataISO, horariosAtualizados)}`
+            : `Esse horário acabou de ficar indisponível na agenda principal.\n\nMe envie outra data no formato *DD/MM* para eu buscar novas opções.`;
+
+          await responder(sendReplyWithTelemetry, mensagem, (patch) => salvarEstado({
+            stage: horariosAtualizados.length > 0 ? 'awaiting_reschedule_time' : 'awaiting_reschedule_date',
+            payload: {
+              ...conversa.payload,
+              rescheduleAvailableSlots: horariosAtualizados,
+            },
+            ...patch,
+          }), {
+            stageBefore: 'awaiting_reschedule_confirmation',
+            stageAfter: horariosAtualizados.length > 0 ? 'awaiting_reschedule_time' : 'awaiting_reschedule_date',
+            resultCode: 'RESCHEDULE_TIME_CONFLICT',
+          });
+          return;
+        }
+
+        const mensagem = `Não consegui remarcar esse agendamento na agenda principal agora.\n\nPor segurança, mantive o horário anterior. Tente novamente em instantes ou fale com a equipe da *${barbearia.nome}*.`;
+        await responder(sendReplyWithTelemetry, mensagem, salvarEstado, {
+          stageBefore: 'awaiting_reschedule_confirmation',
+          stageAfter: 'awaiting_reschedule_confirmation',
+          resultCode: error?.code || 'RESCHEDULE_FAILED',
+        });
+        return;
+      }
+    }
+
     case 'awaiting_review': {
       const nota = parseReviewScore(texto);
 
@@ -1721,6 +2204,7 @@ async function handleIncomingMessage({ barbeariaId, phoneNumber, message, pushNa
         hora,
         nomeBarbearia: barbearia.nome,
         enderecoBarbearia: barbearia.endereco,
+        protocoloAtendimento: criacao.agendamento?.protocolo_atendimento,
       })}\n\nSe preferir acompanhar sua reserva ou solicitar remarcação online, acesse ${CHATBOT_SITE_URL}.`;
 
       await responder(sendReplyWithTelemetry, mensagemConfirmacao, (patch) => salvarEstado({
@@ -1728,6 +2212,7 @@ async function handleIncomingMessage({ barbeariaId, phoneNumber, message, pushNa
         replacePayload: true,
         payload: {
           ultimoAgendamentoId: criacao.agendamento?.id || null,
+          ultimoProtocoloAtendimento: criacao.agendamento?.protocolo_atendimento || null,
         },
         ...patch,
       }), {

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -51,6 +51,7 @@ CREATE TABLE IF NOT EXISTS agendamentos (
   data DATE NOT NULL,
   hora TIME NOT NULL,
   status VARCHAR(20) DEFAULT 'pendente', -- 'pendente', 'confirmado', 'cancelado', 'concluido'
+  protocolo_atendimento VARCHAR(20) UNIQUE,
   observacoes TEXT,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
@@ -72,4 +73,5 @@ CREATE INDEX IF NOT EXISTS idx_barbearias_usuario ON barbearias(usuario_id);
 CREATE INDEX IF NOT EXISTS idx_servicos_barbearia ON servicos(barbearia_id);
 CREATE INDEX IF NOT EXISTS idx_agendamentos_barbearia ON agendamentos(barbearia_id);
 CREATE INDEX IF NOT EXISTS idx_agendamentos_data ON agendamentos(data);
+CREATE INDEX IF NOT EXISTS idx_agendamentos_protocolo_atendimento ON agendamentos(protocolo_atendimento);
 CREATE INDEX IF NOT EXISTS idx_fidelidade_cliente ON fidelidade(cliente_id);


### PR DESCRIPTION
## O que mudou
- Adiciona `protocolo_atendimento` aos agendamentos no backend, bot e schema/migrations.
- Inclui protocolo nas confirmações de agendamento e mensagem automática quando o barbeiro remarca pelo painel.
- Cria endpoints internos para o bot buscar agendamento por protocolo e remarcar na agenda principal.
- Adiciona fluxo no WhatsApp: cliente envia o protocolo, escolhe nova data/horário, confirma com `1`, e recebe a confirmação de remarcação.
- Mantém a sincronização segura com a API principal, incluindo proteção contra colisão de protocolo.

## Por quê
Clientes precisavam remarcar pelo WhatsApp usando um identificador simples, e remarcações feitas pelo painel precisavam avisar automaticamente o cliente.

## Validação
- `npm test -- --runInBand` em `backend`
- `node --check backend/src/controllers/agendamento.js`
- `node --check backend/src/routes/internalBotSync.js`
- `node --check backend/src/services/appointmentProtocol.js`
- `node --check backend/src/services/whatsapp.js`
- `node --check bot/src/services/chatbotConversation.js`
- `node --check bot/src/services/backendAppointments.js`
- `node --check bot/src/services/appointmentProtocol.js`
- `git diff --check`